### PR TITLE
Install binaries in local appdata

### DIFF
--- a/src/IntelOrca.OpenLauncher.Core/Game.cs
+++ b/src/IntelOrca.OpenLauncher.Core/Game.cs
@@ -6,38 +6,24 @@ namespace IntelOrca.OpenLauncher.Core
 {
     public class Game
     {
-        public static Game OpenRCT2 => new Game("OpenRCT2", "openrct2", true, new RepositoryName("OpenRCT2", "OpenRCT2"), new RepositoryName("OpenRCT2", "OpenRCT2-binaries"));
-        public static Game OpenLoco => new Game("OpenLoco", "openloco", false, new RepositoryName("OpenLoco", "OpenLoco"));
+        public static Game OpenRCT2 => new Game("OpenRCT2", "openrct2", new RepositoryName("OpenRCT2", "OpenRCT2"), new RepositoryName("OpenRCT2", "OpenRCT2-binaries"));
+        public static Game OpenLoco => new Game("OpenLoco", "openloco", new RepositoryName("OpenLoco", "OpenLoco"));
 
         public string Name { get; }
         public string BinaryName { get; }
-        public string DefaultLocation { get; }
+        public string BinPath { get; }
         public RepositoryName ReleaseRepository { get; set; }
         public RepositoryName? DevelopRepository { get; set; }
 
-        private Game(string name, string binaryName, bool usesDocuments, RepositoryName releaseRepo, RepositoryName? developRepo = null)
+        private Game(string name, string binaryName, RepositoryName releaseRepo, RepositoryName? developRepo = null)
         {
             Name = name;
             BinaryName = binaryName;
 
-            var root = GetLocation(usesDocuments);
-            DefaultLocation = Path.Combine(root, name);
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            BinPath = Path.Combine(localAppData, name, "bin");
             ReleaseRepository = releaseRepo;
             DevelopRepository = developRepo;
-        }
-
-        private string GetLocation(bool usesDocuments)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return usesDocuments ?
-                    Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) :
-                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            }
-            else
-            {
-                return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            }
         }
     }
 

--- a/src/IntelOrca.OpenLauncher.Core/InstallService.cs
+++ b/src/IntelOrca.OpenLauncher.Core/InstallService.cs
@@ -17,26 +17,12 @@ namespace IntelOrca.OpenLauncher.Core
 
         private readonly Game _game;
 
+        private string VersionFilePath => Path.Combine(_game.BinPath, ".version");
+
+
         public InstallService(Game game)
         {
             _game = game;
-        }
-
-        public string BinPath
-        {
-            get
-            {
-                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                return Path.Combine(localAppData, _game.Name, "bin");
-            }
-        }
-
-        public string VersionFilePath
-        {
-            get
-            {
-                return Path.Combine(BinPath, ".version");
-            }
         }
 
         public string ExecutablePath
@@ -45,7 +31,7 @@ namespace IntelOrca.OpenLauncher.Core
             {
                 var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
                 var binaryName = isWindows ? $"{_game.BinaryName}.exe" : _game.BinaryName;
-                return Path.Combine(BinPath, binaryName);
+                return Path.Combine(_game.BinPath, binaryName);
             }
         }
 
@@ -127,8 +113,8 @@ namespace IntelOrca.OpenLauncher.Core
                 ct.ThrowIfCancellationRequested();
 
                 // Backup old bin directory
-                var binDirectory = BinPath;
-                var backupDirectory = BinPath + ".backup";
+                var binDirectory = _game.BinPath;
+                var backupDirectory = _game.BinPath + ".backup";
                 if (shell.DirectoryExists(binDirectory))
                 {
                     shell.MoveDirectory(binDirectory, backupDirectory);

--- a/src/IntelOrca.OpenLauncher.Core/InstallService.cs
+++ b/src/IntelOrca.OpenLauncher.Core/InstallService.cs
@@ -17,13 +17,26 @@ namespace IntelOrca.OpenLauncher.Core
 
         private readonly Game _game;
 
-
-        private string BinPath => Path.Combine(_game.DefaultLocation, "bin");
-        private string VersionFilePath => Path.Combine(_game.DefaultLocation, "bin", ".version");
-
         public InstallService(Game game)
         {
             _game = game;
+        }
+
+        public string BinPath
+        {
+            get
+            {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                return Path.Combine(localAppData, _game.Name, "bin");
+            }
+        }
+
+        public string VersionFilePath
+        {
+            get
+            {
+                return Path.Combine(BinPath, ".version");
+            }
         }
 
         public string ExecutablePath


### PR DESCRIPTION
The launcher currently tries to put the binaries in a subfolder of the user’s game files, which causes problems with OneDrive and isn’t really a good place to store these to begin with.

This makes the code uses %LOCALAPPDATA% instead. This seems to be the best place, as the binaries can be machine-specific, which is why I didn’t pick %APPDATA%. (This is only relevant to roaming profiles, but we might as well do it right while we’re at it.)

On Linux, this puts the files in ~/.local/share/Open{RCT2,Loco}/bin